### PR TITLE
fix: fix download root directory error

### DIFF
--- a/src/storage/operations/download.rs
+++ b/src/storage/operations/download.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::storage::utils::path::get_relative_path;
+use crate::storage::utils::path::get_root_relative_path;
 use futures::stream::TryStreamExt;
 use opendal::{EntryMode, Operator};
 use std::path::Path;
@@ -42,7 +42,7 @@ impl Downloader for OpenDalDownloader {
         while let Some(entry) = stream.try_next().await? {
             let meta = entry.metadata();
             let remote_file_path = entry.path();
-            let mut relative_path = get_relative_path(remote_file_path, remote_path);
+            let mut relative_path = get_root_relative_path(remote_file_path, remote_path);
             if relative_path.is_empty() {
                 // Fallback: use base name
                 relative_path = Path::new(remote_file_path)

--- a/src/storage/utils/path.rs
+++ b/src/storage/utils/path.rs
@@ -9,24 +9,6 @@ pub fn build_remote_path(base: &str, file_name: &str) -> String {
         .to_string()
 }
 
-/// Get relative path string between a full path and base path.
-pub fn get_relative_path(full_path: &str, base_path: &str) -> String {
-    if full_path == base_path {
-        // For single-file case, return the file name to avoid empty relative path
-        return Path::new(full_path)
-            .file_name()
-            .map(|s| s.to_string_lossy().to_string())
-            .unwrap_or_default();
-    }
-
-    // Strip a prefix from the given path safely
-    full_path
-        .strip_prefix(base_path)
-        .unwrap_or(full_path)
-        .trim_start_matches('/')
-        .to_string()
-}
-
 /// Get relative path string considering the root directory between a full path and base path.
 pub fn get_root_relative_path(full_path: &str, base_path: &str) -> String {
     let full_path = Path::new(full_path.trim_start_matches('/'));


### PR DESCRIPTION
When the source directory has the root directory feature, a recursive directory is created locally when the get parameter is used to download files.

# Steps to Reproduce
## 1. Set up MinIO environment:
```shell
export STORAGE_PROVIDER=minio
export STORAGE_BUCKET=test-bucket
export STORAGE_ACCESS_KEY_ID=minioadmin
export STORAGE_ACCESS_KEY_SECRET=minioadmin
export STORAGE_ENDPOINT=http://localhost:9000
export STORAGE_REGION=us-east-1
```
## 2. download a test file
```shell
./target/release/ossify get /src/lib.rs ./test/
```
# Expected Behavior
Downloaded: src/lib.rs → test/lib.rs

# Actual Behavior
Downloaded: src/lib.rs → ./test/src/lib.rs